### PR TITLE
Remove duplicate sentence from Tutorial

### DIFF
--- a/doc_src/Tutorial.md
+++ b/doc_src/Tutorial.md
@@ -118,10 +118,8 @@ end
 The `Hammer` module also includes  a `check_rate_inc` function, which allows you
 to specify the number by which to increment the current bucket. This is useful
 for rate-limiting APIs which have some idea of "cost", where the cost of a given
-operation can be determined and expressed as an integer function, which allows you
-to specify the number by which to increment the current bucket. This is useful
-for rate-limiting APIs which have some idea of "cost", where the cost of a given
-operation can be determined and expressed as an integer.
+operation can be determined and expressed as an integer, which allows you
+to specify the number by which to increment the current bucket.
 
 Example:
 


### PR DESCRIPTION
The  Custom increments section contained a duplicate sentence regarding the increment number.