### PR TITLE
Set the default pool-overflow to zero

### DIFF
--- a/lib/hammer/supervisor.ex
+++ b/lib/hammer/supervisor.ex
@@ -33,7 +33,7 @@ defmodule Hammer.Supervisor do
   # Private helpers
   defp to_pool_spec(name, {mod, args}) do
     pool_size = args[:pool_size] || 4
-    pool_max_overflow = args[:pool_max_overflow] || 4
+    pool_max_overflow = args[:pool_max_overflow] || 0
 
     opts = [
       name: {:local, name},


### PR DESCRIPTION
The pool auto-scaling behaviour seems to be creating problems occasionally. It seems best to default to zero and let users set a max-overflow themselves if they wish.