### PR TITLE
update elixir

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,9 @@ jobs:
         os: [ubuntu-22.04, ubuntu-20.04]
         elixir_version: [1.13, 1.14, 1.15, 1.16]
         otp_version: [24, 25, 26]
-
+        exclude:
+          - otp_version: 26
+            elixir_version: 1.13
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,9 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, ubuntu-20.04]
-        elixir_version: [1.12.3, 1.13.3, 1.14.1]
-        otp_version: [24, 25]
-        exclude:
-          - otp_version: 25
-            elixir_version: 1.12.3
+        elixir_version: [1.13, 1.14, 1.15, 1.16]
+        otp_version: [24, 25, 26]
+
     steps:
       - uses: actions/checkout@v4
 

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-elixir 1.13.1
+elixir 1.16.0-otp-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- Ensure Elixir version is ~> 1.13 https://github.com/ExHammer/hammer/pull/79
+
 ## 6.1.0 - 2022-06-13
 
 ### Changed

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,7 @@ defmodule Hammer.Mixfile do
       app: :hammer,
       description: "A rate-limiter with plugable backends.",
       version: @version,
-      elixir: "~> 1.6",
+      elixir: "~> 1.13",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
This PR updates CI to use latest Elixir and Erlang versions and ensures Elixir is `~> 1.13` in `mix.exs`.

---

<sup>This PR is part of recreating #72 in a non-breaking way.
To avoid spamming this repo with PRs, I'm going to create the new ones only after the currently open ones are merged.</sup>