### PR TITLE
Fix `Hammer.check_rate` and `Hammer.check_rate_inc` remapping info in migration guide

### DIFF
--- a/guides/upgrade-v7.md
+++ b/guides/upgrade-v7.md
@@ -52,8 +52,8 @@ end
 
 ## Change to Backend Configuration
 
-* Remapped all the  `Hammer.check_rate/3` and  `Hammer.check_rate/4` to `Hammer.hit/4`.
-* Remapped all the  `Hammer.check_rate_inc/4` and  `Hammer.check_rate_inc/5` to `Hammer.inc/4`.
+* Remapped all the  `Hammer.check_rate/3` and  `Hammer.check_rate/4` to `Hammer.hit/3`.
+* Remapped all the  `Hammer.check_rate_inc/4` and  `Hammer.check_rate_inc/5` to `Hammer.hit/4`.
 * for the `Hammer.delete_buckets`, you need to remove them as there no true replacement. You could potentially use `Hammer.ETS.set/1` to reset specific key
 * for the `Hammer.make_rate_checker`, you need to remove them as there no replacement.
 


### PR DESCRIPTION
Going through the migration right now, I think `Hammer.check_rate` and `Hammer.check_rate_in` were remapped to `Hammer.hit/3` and `Hammer.hit/4` respectively, rather than `Hammer.inc`