### PR TITLE
Fix possible race condition when using atomic on creating a key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 7.0.1 - 2025-03-04
+
+- Fix race condition in Atomic backends during creation of key.
+
 ## 7.0.0 - 2025-02-06
 
 - Release candidate for 7.0.0. See [./guides/upgrade-v7.md] for upgrade instructions.

--- a/lib/hammer/atomic/fix_window.ex
+++ b/lib/hammer/atomic/fix_window.ex
@@ -114,7 +114,7 @@ defmodule Hammer.Atomic.FixWindow do
         end
 
       [] ->
-        :ets.insert(table, {full_key, :atomics.new(2, signed: false)})
+        :ets.insert_new(table, {full_key, :atomics.new(2, signed: false)})
         hit(table, key, scale, limit, increment)
     end
   end

--- a/lib/hammer/atomic/leaky_bucket.ex
+++ b/lib/hammer/atomic/leaky_bucket.ex
@@ -136,7 +136,7 @@ defmodule Hammer.Atomic.LeakyBucket do
         end
 
       [] ->
-        :ets.insert(table, {key, :atomics.new(2, signed: false)})
+        :ets.insert_new(table, {key, :atomics.new(2, signed: false)})
         hit(table, key, leak_rate, capacity, cost)
     end
   end

--- a/lib/hammer/atomic/token_bucket.ex
+++ b/lib/hammer/atomic/token_bucket.ex
@@ -140,8 +140,11 @@ defmodule Hammer.Atomic.TokenBucket do
 
       [] ->
         atomic = :atomics.new(2, signed: false)
-        :ets.insert(table, {key, atomic})
-        :atomics.exchange(atomic, 1, capacity)
+
+        if :ets.insert_new(table, {key, atomic}) do
+          :atomics.exchange(atomic, 1, capacity)
+        end
+
         hit(table, key, refill_rate, capacity, cost)
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Hammer.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/ExHammer/hammer"
-  @version "7.0.0"
+  @version "7.0.1"
 
   def project do
     [


### PR DESCRIPTION
#129 was reported. It is possible that on ETS.insert we end up in a race condition if new key is created concurrently. 

This MR uses insert_new that will not replace an existing key and should make instead a noop instead of ovewriting the key and possibly resetting the value and missing "hit"

