### PR TITLE
Add :fix_window_per_key algorithm for ETS and Atomic backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Add `:fix_window_per_key` algorithm for ETS and Atomic backends — a fixed-window variant whose window is anchored to first hit per key instead of a globally-aligned wall-clock epoch. Same one-entry-per-key memory profile as `:fix_window`. The 2x boundary burst is still possible per key, but boundaries are no longer globally synchronized. (#181)
+
 ## 7.3.0 - 2026-03-31
 
 - Add `expires_at/2` API for fix_window algorithm (#178)

--- a/README.md
+++ b/README.md
@@ -36,9 +36,11 @@ Each backend supports multiple algorithms. Not all of them are available for all
 | Algorithm | Backend |
 | --------- | ------- |
 | [Hammer.Atomic.FixWindow](https://hexdocs.pm/hammer/Hammer.Atomic.FixWindow.html) | [Hammer.Atomic](https://hexdocs.pm/hammer/Hammer.Atomic.html) |
+| [Hammer.Atomic.FixWindowPerKey](https://hexdocs.pm/hammer/Hammer.Atomic.FixWindowPerKey.html) | [Hammer.Atomic](https://hexdocs.pm/hammer/Hammer.Atomic.html) |
 | [Hammer.Atomic.LeakyBucket](https://hexdocs.pm/hammer/Hammer.Atomic.LeakyBucket.html) | [Hammer.Atomic](https://hexdocs.pm/hammer/Hammer.Atomic.html) |
 | [Hammer.Atomic.TokenBucket](https://hexdocs.pm/hammer/Hammer.Atomic.TokenBucket.html) | [Hammer.Atomic](https://hexdocs.pm/hammer/Hammer.Atomic.html) |
 | [Hammer.ETS.FixWindow](https://hexdocs.pm/hammer/Hammer.ETS.FixWindow.html) | [Hammer.ETS](https://hexdocs.pm/hammer/Hammer.ETS.html) |
+| [Hammer.ETS.FixWindowPerKey](https://hexdocs.pm/hammer/Hammer.ETS.FixWindowPerKey.html) | [Hammer.ETS](https://hexdocs.pm/hammer/Hammer.ETS.html) |
 | [Hammer.ETS.LeakyBucket](https://hexdocs.pm/hammer/Hammer.ETS.LeakyBucket.html) | [Hammer.ETS](https://hexdocs.pm/hammer/Hammer.ETS.html) |
 | [Hammer.ETS.TokenBucket](https://hexdocs.pm/hammer/Hammer.ETS.TokenBucket.html) | [Hammer.ETS](https://hexdocs.pm/hammer/Hammer.ETS.html) |
 | [Hammer.ETS.SlidingWindow](https://hexdocs.pm/hammer/Hammer.ETS.SlidingWindow.html) | [Hammer.ETS](https://hexdocs.pm/hammer/Hammer.ETS.html) |
@@ -63,6 +65,13 @@ Here's a comparison of the different rate limiting algorithms to help you choose
 - Potential edge case: Up to 2x requests possible at window boundaries
 - Best for: Basic API limits where occasional bursts are acceptable
 
+### [Fixed Window Per Key](https://hexdocs.pm/hammer/Hammer.Atomic.FixWindowPerKey.html)
+- Same low overhead and one-entry-per-key footprint as Fixed Window
+- Each key's window is anchored to its first hit, not a globally aligned wall-clock boundary
+- 2x boundary burst is still possible per key, but boundaries are not globally synchronized so they cannot be exploited deterministically
+- Same semantics as the common Redis `INCR + EXPIRE NX` pattern
+- Best for: Basic rate limiting where globally-synchronized boundaries are undesirable
+
 ### [Leaky Bucket](https://hexdocs.pm/hammer/Hammer.Atomic.LeakyBucket.html)
 - Provides smooth, consistent request rate
 - Requests "leak" out at constant rate
@@ -83,6 +92,7 @@ Here's a comparison of the different rate limiting algorithms to help you choose
 
 Selection Guide:
 - Need simple implementation? → Fixed Window
+- Want Fixed Window simplicity but without globally-synchronized boundaries? → Fixed Window Per Key
 - Need smooth output rate? → Leaky Bucket
 - Need burst tolerance? → Token Bucket
 - Need precise limits? → Sliding Window

--- a/lib/hammer/atomic.ex
+++ b/lib/hammer/atomic.ex
@@ -17,7 +17,7 @@ defmodule Hammer.Atomic do
   Runtime configuration:
   - `:clean_period` - (in milliseconds) period to clean up expired entries, defaults to 1 minute
   - `:key_older_than` - (in milliseconds) maximum age for entries before they are cleaned up, defaults to 24 hours
-  - `:algorithm` - the rate limiting algorithm to use, one of: `:fix_window`, `:leaky_bucket`, `:token_bucket`. Defaults to `:fix_window`
+  - `:algorithm` - the rate limiting algorithm to use, one of: `:fix_window`, `:fix_window_per_key`, `:leaky_bucket`, `:token_bucket`. Defaults to `:fix_window`
   - `:before_clean` - optional callback invoked with expired entries before they are deleted.
     Accepts a function `(algorithm :: atom(), entries :: [map()]) -> any()` or an MFA tuple
     `{module, function, extra_args}`. Each entry is a map with `:key`, `:value`, and `:expired_at` (ms).
@@ -37,6 +37,10 @@ defmodule Hammer.Atomic do
 
   - `:fix_window` - Fixed window rate limiting (default)
     Simple counting within fixed time windows. See [Hammer.Atomic.FixWindow](Hammer.Atomic.FixWindow.html) for more details.
+
+  - `:fix_window_per_key` - Per-key fixed window rate limiting
+    Like `:fix_window`, but each key's window is anchored to its first hit rather than a
+    globally-aligned wall-clock boundary. See [Hammer.Atomic.FixWindowPerKey](Hammer.Atomic.FixWindowPerKey.html) for more details.
 
   - `:leaky_bucket` - Leaky bucket rate limiting
     Smooth rate limiting with a fixed rate of tokens. See [Hammer.Atomic.LeakyBucket](Hammer.Atomic.LeakyBucket.html) for more details.
@@ -78,6 +82,9 @@ defmodule Hammer.Atomic do
         :fix_window ->
           Hammer.Atomic.FixWindow
 
+        :fix_window_per_key ->
+          Hammer.Atomic.FixWindowPerKey
+
         :sliding_window ->
           Hammer.Atomic.SlidingWindow
 
@@ -89,7 +96,7 @@ defmodule Hammer.Atomic do
 
         _module ->
           raise ArgumentError, """
-          Hammer requires a valid backend to be specified. Must be one of: :atomic, :fix_window, :sliding_window, :leaky_bucket, :token_bucket.
+          Hammer requires a valid backend to be specified. Must be one of: :atomic, :fix_window, :fix_window_per_key, :sliding_window, :leaky_bucket, :token_bucket.
           If none is specified, :fix_window is used.
 
           Example:
@@ -223,6 +230,7 @@ defmodule Hammer.Atomic do
   def handle_info(:clean, config) do
     case config.algorithm_module do
       Hammer.Atomic.FixWindow -> clean_fix_window(config)
+      Hammer.Atomic.FixWindowPerKey -> clean_fix_window(config)
       _ -> clean_bucket(config)
     end
 
@@ -282,6 +290,7 @@ defmodule Hammer.Atomic do
   end
 
   defp algorithm_name(Hammer.Atomic.FixWindow), do: :fix_window
+  defp algorithm_name(Hammer.Atomic.FixWindowPerKey), do: :fix_window_per_key
   defp algorithm_name(Hammer.Atomic.TokenBucket), do: :token_bucket
   defp algorithm_name(Hammer.Atomic.LeakyBucket), do: :leaky_bucket
 

--- a/lib/hammer/atomic/fix_window_per_key.ex
+++ b/lib/hammer/atomic/fix_window_per_key.ex
@@ -1,0 +1,219 @@
+defmodule Hammer.Atomic.FixWindowPerKey do
+  @moduledoc """
+  This module implements a per-key fixed window rate-limiting algorithm using
+  Erlang's `:atomics` module for atomic counters.
+
+  Like the standard fixed window algorithm, requests are counted within a window of
+  duration `scale`. Unlike the standard fixed window — which aligns every key to the
+  same wall-clock boundary (multiples of `scale` since the Unix epoch) — this variant
+  anchors each key's window to that key's **first hit**.
+
+  For example, with a scale of 60 seconds:
+
+  - User A's first request at `12:00:37` → A's window runs until `12:01:37`
+  - User B's first request at `12:00:51` → B's window runs until `12:01:51`
+
+  Once a key's window expires, the next hit for that key opens a fresh window starting
+  at that moment.
+
+  ## The algorithm
+
+  1. When a request comes in for a key:
+     - If the key has an active window (`expires_at > now`), increment its atomic
+       counter.
+     - Otherwise, start a new window: reset the counter to `increment` and set
+       `expires_at = now + scale`.
+  2. If the counter is `<= limit` → allow. Otherwise → deny and return time until the
+     current window expires.
+
+  ## When to use this vs `:fix_window` and `:sliding_window`
+
+  The 2x boundary burst that affects `:fix_window` is **still theoretically possible**
+  here, just at a per-key boundary instead of a globally synchronized one. The
+  practical benefit is that boundaries are not globally synchronized, so they are
+  harder to exploit deterministically, and a key has to wait a full `scale` between
+  burst opportunities.
+
+  This is essentially the same algorithm as the common Redis `INCR + EXPIRE NX`
+  rate-limiting pattern.
+
+  ## Options
+
+  - `:clean_period` - How often to run the cleanup process (in milliseconds). Defaults
+    to 1 minute.
+  - `:key_older_than` - Maximum age for entries (in milliseconds) past their expiry
+    before they are removed during cleanup. Defaults to 24 hours.
+
+  ## Example
+
+  ### Example configuration:
+
+      MyApp.RateLimit.start_link(
+        clean_period: :timer.minutes(5),
+      )
+
+  ### Example usage:
+
+      defmodule MyApp.RateLimit do
+        use Hammer, backend: :atomic, algorithm: :fix_window_per_key
+      end
+
+      MyApp.RateLimit.start_link(clean_period: :timer.minutes(1))
+
+      # Allow 10 requests per second
+      MyApp.RateLimit.hit("user_123", 1000, 10)
+  """
+  alias Hammer.Atomic
+
+  @doc false
+  @spec ets_opts() :: list()
+  def ets_opts do
+    [
+      :named_table,
+      :set,
+      :public,
+      {:read_concurrency, true},
+      {:write_concurrency, true},
+      {:decentralized_counters, true}
+    ]
+  end
+
+  @doc """
+  Checks if a key is allowed to perform an action based on the per-key fixed window
+  algorithm.
+  """
+  @spec hit(
+          table :: atom(),
+          key :: term(),
+          scale :: pos_integer(),
+          limit :: pos_integer(),
+          increment :: pos_integer()
+        ) :: {:allow, non_neg_integer()} | {:deny, non_neg_integer()}
+  def hit(table, key, scale, limit, increment) do
+    now = Atomic.now()
+
+    case :ets.lookup(table, key) do
+      [{_, atomic}] ->
+        do_hit(atomic, now, scale, limit, increment)
+
+      [] ->
+        :ets.insert_new(table, {key, :atomics.new(2, signed: false)})
+        hit(table, key, scale, limit, increment)
+    end
+  end
+
+  defp do_hit(atomic, now, scale, limit, increment) do
+    expires_at = :atomics.get(atomic, 2)
+
+    if expires_at > now do
+      count = :atomics.add_get(atomic, 1, increment)
+      if count <= limit, do: {:allow, count}, else: {:deny, expires_at - now}
+    else
+      :atomics.put(atomic, 1, increment)
+      :atomics.exchange(atomic, 2, now + scale)
+      if increment <= limit, do: {:allow, increment}, else: {:deny, scale}
+    end
+  end
+
+  @doc """
+  Increments the counter for a given key without performing a limit check.
+  """
+  @spec inc(
+          table :: atom(),
+          key :: term(),
+          scale :: pos_integer(),
+          increment :: pos_integer()
+        ) :: non_neg_integer()
+  def inc(table, key, scale, increment) do
+    now = Atomic.now()
+
+    case :ets.lookup(table, key) do
+      [{_, atomic}] ->
+        expires_at = :atomics.get(atomic, 2)
+
+        if expires_at > now do
+          :atomics.add_get(atomic, 1, increment)
+        else
+          new_expires_at = now + scale
+          :atomics.put(atomic, 1, increment)
+          :atomics.exchange(atomic, 2, new_expires_at)
+          increment
+        end
+
+      [] ->
+        :ets.insert(table, {key, :atomics.new(2, signed: false)})
+        inc(table, key, scale, increment)
+    end
+  end
+
+  @doc """
+  Sets the counter for a given key, refreshing the window to `now + scale`.
+  """
+  @spec set(
+          table :: atom(),
+          key :: term(),
+          scale :: pos_integer(),
+          count :: non_neg_integer()
+        ) :: non_neg_integer()
+  def set(table, key, scale, count) do
+    new_expires_at = Atomic.now() + scale
+
+    case :ets.lookup(table, key) do
+      [{_, atomic}] ->
+        :atomics.exchange(atomic, 1, count)
+        :atomics.exchange(atomic, 2, new_expires_at)
+        count
+
+      [] ->
+        :ets.insert(table, {key, :atomics.new(2, signed: false)})
+        set(table, key, scale, count)
+    end
+  end
+
+  @doc """
+  Returns the current count for a given key.
+
+  Returns `0` if the key has no active window (either never hit, or window has
+  expired).
+  """
+  @spec get(table :: atom(), key :: term(), scale :: pos_integer()) :: non_neg_integer()
+  def get(table, key, _scale) do
+    now = Atomic.now()
+
+    case :ets.lookup(table, key) do
+      [{_, atomic}] ->
+        expires_at = :atomics.get(atomic, 2)
+        if expires_at > now, do: :atomics.get(atomic, 1), else: 0
+
+      [] ->
+        0
+    end
+  end
+
+  @doc """
+  Returns the expiration time (in milliseconds) of the current window for a given key.
+
+  Returns `0` if the key has no active window.
+  """
+  @spec expires_at(table :: atom(), key :: term(), scale :: pos_integer()) :: non_neg_integer()
+  def expires_at(table, key, _scale) do
+    now = Atomic.now()
+
+    case :ets.lookup(table, key) do
+      [{_, atomic}] ->
+        expires_at = :atomics.get(atomic, 2)
+        if expires_at > now, do: expires_at, else: 0
+
+      [] ->
+        0
+    end
+  end
+
+  @doc false
+  @spec normalize_entry(key :: term(), atomic :: reference()) :: map()
+  def normalize_entry(key, atomic) do
+    count = :atomics.get(atomic, 1)
+    expires_at = :atomics.get(atomic, 2)
+    %{key: key, value: count, expired_at: expires_at}
+  end
+end

--- a/lib/hammer/atomic/fix_window_per_key.ex
+++ b/lib/hammer/atomic/fix_window_per_key.ex
@@ -102,16 +102,32 @@ defmodule Hammer.Atomic.FixWindowPerKey do
     end
   end
 
+  # Sentinel written to expires_at slot while a reset is in progress.
+  # All other processes that see this value spin-retry until the winner
+  # has written both the new counter and the real expires_at.
+  @reset_lock 0xFFFFFFFFFFFFFFFF
+
   defp do_hit(atomic, now, scale, limit, increment) do
     expires_at = :atomics.get(atomic, 2)
 
-    if expires_at > now do
-      count = :atomics.add_get(atomic, 1, increment)
-      if count <= limit, do: {:allow, count}, else: {:deny, expires_at - now}
-    else
-      :atomics.put(atomic, 1, increment)
-      :atomics.exchange(atomic, 2, now + scale)
-      if increment <= limit, do: {:allow, increment}, else: {:deny, scale}
+    cond do
+      expires_at == @reset_lock ->
+        do_hit(atomic, now, scale, limit, increment)
+
+      expires_at > now ->
+        count = :atomics.add_get(atomic, 1, increment)
+        if count <= limit, do: {:allow, count}, else: {:deny, expires_at - now}
+
+      true ->
+        case :atomics.compare_exchange(atomic, 2, expires_at, @reset_lock) do
+          :ok ->
+            :atomics.put(atomic, 1, increment)
+            :atomics.put(atomic, 2, now + scale)
+            if increment <= limit, do: {:allow, increment}, else: {:deny, scale}
+
+          _ ->
+            do_hit(atomic, now, scale, limit, increment)
+        end
     end
   end
 
@@ -131,17 +147,29 @@ defmodule Hammer.Atomic.FixWindowPerKey do
       [{_, atomic}] ->
         expires_at = :atomics.get(atomic, 2)
 
-        if expires_at > now do
-          :atomics.add_get(atomic, 1, increment)
-        else
-          new_expires_at = now + scale
-          :atomics.put(atomic, 1, increment)
-          :atomics.exchange(atomic, 2, new_expires_at)
-          increment
+        cond do
+          expires_at == @reset_lock ->
+            inc(table, key, scale, increment)
+
+          expires_at > now ->
+            :atomics.add_get(atomic, 1, increment)
+
+          true ->
+            new_expires_at = now + scale
+
+            case :atomics.compare_exchange(atomic, 2, expires_at, @reset_lock) do
+              :ok ->
+                :atomics.put(atomic, 1, increment)
+                :atomics.put(atomic, 2, new_expires_at)
+                increment
+
+              _ ->
+                inc(table, key, scale, increment)
+            end
         end
 
       [] ->
-        :ets.insert(table, {key, :atomics.new(2, signed: false)})
+        :ets.insert_new(table, {key, :atomics.new(2, signed: false)})
         inc(table, key, scale, increment)
     end
   end

--- a/lib/hammer/atomic/fix_window_per_key.ex
+++ b/lib/hammer/atomic/fix_window_per_key.ex
@@ -123,12 +123,16 @@ defmodule Hammer.Atomic.FixWindowPerKey do
           :ok ->
             :atomics.put(atomic, 1, increment)
             :atomics.put(atomic, 2, now + scale)
-            if increment <= limit, do: {:allow, increment}, else: {:deny, scale}
+            allow_or_deny(increment, limit, scale)
 
           _ ->
             do_hit(atomic, now, scale, limit, increment)
         end
     end
+  end
+
+  defp allow_or_deny(increment, limit, scale) do
+    if increment <= limit, do: {:allow, increment}, else: {:deny, scale}
   end
 
   @doc """
@@ -145,32 +149,34 @@ defmodule Hammer.Atomic.FixWindowPerKey do
 
     case :ets.lookup(table, key) do
       [{_, atomic}] ->
-        expires_at = :atomics.get(atomic, 2)
-
-        cond do
-          expires_at == @reset_lock ->
-            inc(table, key, scale, increment)
-
-          expires_at > now ->
-            :atomics.add_get(atomic, 1, increment)
-
-          true ->
-            new_expires_at = now + scale
-
-            case :atomics.compare_exchange(atomic, 2, expires_at, @reset_lock) do
-              :ok ->
-                :atomics.put(atomic, 1, increment)
-                :atomics.put(atomic, 2, new_expires_at)
-                increment
-
-              _ ->
-                inc(table, key, scale, increment)
-            end
-        end
+        do_inc(atomic, now, scale, increment)
 
       [] ->
         :ets.insert_new(table, {key, :atomics.new(2, signed: false)})
         inc(table, key, scale, increment)
+    end
+  end
+
+  defp do_inc(atomic, now, scale, increment) do
+    expires_at = :atomics.get(atomic, 2)
+
+    cond do
+      expires_at == @reset_lock ->
+        do_inc(atomic, now, scale, increment)
+
+      expires_at > now ->
+        :atomics.add_get(atomic, 1, increment)
+
+      true ->
+        case :atomics.compare_exchange(atomic, 2, expires_at, @reset_lock) do
+          :ok ->
+            :atomics.put(atomic, 1, increment)
+            :atomics.put(atomic, 2, now + scale)
+            increment
+
+          _ ->
+            do_inc(atomic, now, scale, increment)
+        end
     end
   end
 

--- a/lib/hammer/ets.ex
+++ b/lib/hammer/ets.ex
@@ -16,7 +16,7 @@ defmodule Hammer.ETS do
   Runtime configuration:
   - `:clean_period` - (in milliseconds) period to clean up expired entries, defaults to 1 minute
   - `:key_older_than` - (in milliseconds) maximum age for entries before they are cleaned up, defaults to 1 hour
-  - `:algorithm` - the rate limiting algorithm to use, one of: `:fix_window`, `:sliding_window`, `:leaky_bucket`, `:token_bucket`. Defaults to `:fix_window`
+  - `:algorithm` - the rate limiting algorithm to use, one of: `:fix_window`, `:fix_window_per_key`, `:sliding_window`, `:leaky_bucket`, `:token_bucket`. Defaults to `:fix_window`
   - `:before_clean` - optional callback invoked with expired entries before they are deleted.
     Accepts a function `(algorithm :: atom(), entries :: [map()]) -> any()` or an MFA tuple
     `{module, function, extra_args}`. Each entry is a map with `:key`, `:value`, and `:expired_at` (ms).
@@ -34,6 +34,10 @@ defmodule Hammer.ETS do
   The ETS backend supports the following algorithms:
     - `:fix_window` - Fixed window rate limiting (default)
       Simple counting within fixed time windows. See [Hammer.ETS.FixWindow](Hammer.ETS.FixWindow.html) for more details.
+
+  - `:fix_window_per_key` - Per-key fixed window rate limiting
+    Like `:fix_window`, but each key's window is anchored to its first hit rather than a
+    globally-aligned wall-clock boundary. See [Hammer.ETS.FixWindowPerKey](Hammer.ETS.FixWindowPerKey.html) for more details.
 
   - `:leaky_bucket` - Leaky bucket rate limiting
     Smooth rate limiting with a fixed rate of tokens. See [Hammer.ETS.LeakyBucket](Hammer.ETS.LeakyBucket.html) for more details.
@@ -77,6 +81,9 @@ defmodule Hammer.ETS do
         :fix_window ->
           Hammer.ETS.FixWindow
 
+        :fix_window_per_key ->
+          Hammer.ETS.FixWindowPerKey
+
         :sliding_window ->
           Hammer.ETS.SlidingWindow
 
@@ -88,7 +95,7 @@ defmodule Hammer.ETS do
 
         _module ->
           raise ArgumentError, """
-          Hammer requires a valid backend to be specified. Must be one of: :ets,:fix_window, :sliding_window, :leaky_bucket, :token_bucket.
+          Hammer requires a valid backend to be specified. Must be one of: :ets, :fix_window, :fix_window_per_key, :sliding_window, :leaky_bucket, :token_bucket.
           If none is specified, :fix_window is used.
 
           Example:
@@ -249,6 +256,7 @@ defmodule Hammer.ETS do
   end
 
   defp algorithm_name(Hammer.ETS.FixWindow), do: :fix_window
+  defp algorithm_name(Hammer.ETS.FixWindowPerKey), do: :fix_window_per_key
   defp algorithm_name(Hammer.ETS.SlidingWindow), do: :sliding_window
   defp algorithm_name(Hammer.ETS.TokenBucket), do: :token_bucket
   defp algorithm_name(Hammer.ETS.LeakyBucket), do: :leaky_bucket

--- a/lib/hammer/ets/fix_window_per_key.ex
+++ b/lib/hammer/ets/fix_window_per_key.ex
@@ -1,0 +1,220 @@
+defmodule Hammer.ETS.FixWindowPerKey do
+  @moduledoc """
+  This module implements a per-key fixed window rate-limiting algorithm.
+
+  Like the standard fixed window algorithm, requests are counted within a window of
+  duration `scale`. Unlike the standard fixed window — which aligns every key to the
+  same wall-clock boundary (multiples of `scale` since the Unix epoch) — this variant
+  anchors each key's window to that key's **first hit**.
+
+  For example, with a scale of 60 seconds:
+
+  - User A's first request at `12:00:37` → A's window runs until `12:01:37`
+  - User B's first request at `12:00:51` → B's window runs until `12:01:51`
+
+  Once a key's window expires, the next hit for that key opens a fresh window starting
+  at that moment.
+
+  ## The algorithm
+
+  1. When a request comes in for a key:
+     - If the key has an active window (`expires_at > now`), increment its counter.
+     - Otherwise, start a new window: reset the counter to `increment` and set
+       `expires_at = now + scale`.
+  2. If the counter is `<= limit` → allow. Otherwise → deny and return time until the
+     current window expires.
+  3. Expired entries are cleaned up by the periodic cleanup task.
+
+  ## When to use this vs `:fix_window` and `:sliding_window`
+
+  The 2x boundary burst that affects `:fix_window` is **still theoretically possible**
+  here, just at a per-key boundary instead of a globally synchronized one. Example:
+
+  - 100 requests at `12:00:37` (window `[12:00:37, 12:01:37)`)
+  - 100 more at `12:01:38` (window `[12:01:38, 12:02:38)`)
+  - That's 200 requests in roughly one second.
+
+  The practical benefit is that boundaries are not globally synchronized. With
+  `:fix_window`, every key flips at the same wall-clock instant (e.g. every minute on
+  the minute), so an attacker who knows your `scale` can time bursts deterministically.
+  With `:fix_window_per_key`, each key's boundary is at a different moment, and a key
+  has to wait a full `scale` between burst opportunities.
+
+  Choose `:fix_window_per_key` when:
+
+  - You want `:fix_window`-style simplicity and the same one-entry-per-key memory
+    footprint, but find globally-synchronized boundaries undesirable.
+  - You're familiar with the Redis `INCR + EXPIRE NX` rate-limiting pattern — this is
+    essentially the same algorithm.
+
+  Choose `:fix_window` when boundaries aligned to the wall clock are useful for your
+  use case (clear time-based quotas like "100 requests per minute, starting on the
+  minute").
+
+  Choose `:sliding_window` when you need precise enforcement — never more than `limit`
+  in *any* `scale`-length interval. It costs more memory (one entry per request) and
+  CPU per check, but eliminates the boundary burst entirely.
+
+  ## Options
+
+  - `:clean_period` - How often to run the cleanup process (in milliseconds). Defaults
+    to 1 minute. The cleanup process removes expired entries.
+
+  ## Example
+
+  ### Example configuration:
+
+      MyApp.RateLimit.start_link(
+        clean_period: :timer.minutes(5),
+      )
+
+  ### Example usage:
+
+      defmodule MyApp.RateLimit do
+        use Hammer, backend: :ets, algorithm: :fix_window_per_key
+      end
+
+      MyApp.RateLimit.start_link(clean_period: :timer.minutes(1))
+
+      # Allow 10 requests per second
+      MyApp.RateLimit.hit("user_123", 1000, 10)
+  """
+  alias Hammer.ETS
+
+  @doc false
+  @spec ets_opts() :: list()
+  def ets_opts do
+    [
+      :named_table,
+      :set,
+      :public,
+      {:read_concurrency, true},
+      {:write_concurrency, true},
+      {:decentralized_counters, true}
+    ]
+  end
+
+  @doc """
+  Checks if a key is allowed to perform an action based on the per-key fixed window
+  algorithm.
+  """
+  @spec hit(
+          table :: atom(),
+          key :: term(),
+          scale :: pos_integer(),
+          limit :: pos_integer(),
+          increment :: pos_integer()
+        ) :: {:allow, non_neg_integer()} | {:deny, non_neg_integer()}
+  def hit(table, key, scale, limit, increment) do
+    now = ETS.now()
+
+    case :ets.lookup(table, key) do
+      [{^key, _count, expires_at}] when expires_at > now ->
+        count = ETS.update_counter(table, key, increment, expires_at)
+
+        if count <= limit do
+          {:allow, count}
+        else
+          {:deny, expires_at - now}
+        end
+
+      _ ->
+        new_expires_at = now + scale
+        :ets.insert(table, {key, increment, new_expires_at})
+
+        if increment <= limit do
+          {:allow, increment}
+        else
+          {:deny, scale}
+        end
+    end
+  end
+
+  @doc """
+  Increments the counter for a given key without performing a limit check.
+  """
+  @spec inc(
+          table :: atom(),
+          key :: term(),
+          scale :: pos_integer(),
+          increment :: pos_integer()
+        ) :: non_neg_integer()
+  def inc(table, key, scale, increment) do
+    now = ETS.now()
+
+    case :ets.lookup(table, key) do
+      [{^key, _count, expires_at}] when expires_at > now ->
+        ETS.update_counter(table, key, increment, expires_at)
+
+      _ ->
+        new_expires_at = now + scale
+        :ets.insert(table, {key, increment, new_expires_at})
+        increment
+    end
+  end
+
+  @doc """
+  Sets the counter for a given key, refreshing the window to `now + scale`.
+  """
+  @spec set(table :: atom(), key :: term(), scale :: pos_integer(), count :: non_neg_integer()) ::
+          non_neg_integer()
+  def set(table, key, scale, count) do
+    new_expires_at = ETS.now() + scale
+    :ets.insert(table, {key, count, new_expires_at})
+    count
+  end
+
+  @doc """
+  Returns the current count for a given key.
+
+  Returns `0` if the key has no active window (either never hit, or window has expired).
+  """
+  @spec get(table :: atom(), key :: term(), scale :: pos_integer()) :: non_neg_integer()
+  def get(table, key, _scale) do
+    now = ETS.now()
+
+    case :ets.lookup(table, key) do
+      [{^key, count, expires_at}] when expires_at > now -> count
+      _ -> 0
+    end
+  end
+
+  @doc """
+  Returns the expiration time (in milliseconds) of the current window for a given key.
+
+  Returns `0` if the key has no active window.
+  """
+  @spec expires_at(table :: atom(), key :: term(), scale :: pos_integer()) :: non_neg_integer()
+  def expires_at(table, key, _scale) do
+    now = ETS.now()
+
+    case :ets.lookup(table, key) do
+      [{^key, _count, expires_at}] when expires_at > now -> expires_at
+      _ -> 0
+    end
+  end
+
+  @doc """
+  Cleans up all of the expired entries from the table.
+  """
+  @spec clean(config :: ETS.config()) :: non_neg_integer()
+  def clean(config) do
+    match_spec = [{{:_, :_, :"$1"}, [], [{:<, :"$1", {:const, ETS.now()}}]}]
+    :ets.select_delete(config.table, match_spec)
+  end
+
+  @doc false
+  @spec select_expired(config :: ETS.config()) :: list()
+  def select_expired(config) do
+    match_spec = [{{:_, :_, :"$1"}, [{:<, :"$1", {:const, ETS.now()}}], [:"$_"]}]
+    :ets.select(config.table, match_spec)
+  end
+
+  @doc false
+  @spec normalize_expired(expired :: list()) :: list(map())
+  def normalize_expired(expired) do
+    Enum.map(expired, fn {key, count, expires_at} ->
+      %{key: key, value: count, expired_at: expires_at}
+    end)
+  end
+end

--- a/lib/hammer/ets/fix_window_per_key.ex
+++ b/lib/hammer/ets/fix_window_per_key.ex
@@ -123,18 +123,22 @@ defmodule Hammer.ETS.FixWindowPerKey do
 
         cond do
           :ets.insert_new(table, {key, increment, new_expires_at}) ->
-            if increment <= limit, do: {:allow, increment}, else: {:deny, scale}
+            allow_or_deny(increment, limit, scale)
 
           :ets.select_replace(table, [
             {{key, :_, :"$1"}, [{:<, :"$1", {:const, now}}],
              [{:const, {key, increment, new_expires_at}}]}
           ]) == 1 ->
-            if increment <= limit, do: {:allow, increment}, else: {:deny, scale}
+            allow_or_deny(increment, limit, scale)
 
           true ->
             hit(table, key, scale, limit, increment)
         end
     end
+  end
+
+  defp allow_or_deny(increment, limit, scale) do
+    if increment <= limit, do: {:allow, increment}, else: {:deny, scale}
   end
 
   @doc """

--- a/lib/hammer/ets/fix_window_per_key.ex
+++ b/lib/hammer/ets/fix_window_per_key.ex
@@ -120,12 +120,19 @@ defmodule Hammer.ETS.FixWindowPerKey do
 
       _ ->
         new_expires_at = now + scale
-        :ets.insert(table, {key, increment, new_expires_at})
 
-        if increment <= limit do
-          {:allow, increment}
-        else
-          {:deny, scale}
+        cond do
+          :ets.insert_new(table, {key, increment, new_expires_at}) ->
+            if increment <= limit, do: {:allow, increment}, else: {:deny, scale}
+
+          :ets.select_replace(table, [
+            {{key, :_, :"$1"}, [{:<, :"$1", {:const, now}}],
+             [{:const, {key, increment, new_expires_at}}]}
+          ]) == 1 ->
+            if increment <= limit, do: {:allow, increment}, else: {:deny, scale}
+
+          true ->
+            hit(table, key, scale, limit, increment)
         end
     end
   end
@@ -148,8 +155,20 @@ defmodule Hammer.ETS.FixWindowPerKey do
 
       _ ->
         new_expires_at = now + scale
-        :ets.insert(table, {key, increment, new_expires_at})
-        increment
+
+        cond do
+          :ets.insert_new(table, {key, increment, new_expires_at}) ->
+            increment
+
+          :ets.select_replace(table, [
+            {{key, :_, :"$1"}, [{:<, :"$1", {:const, now}}],
+             [{:const, {key, increment, new_expires_at}}]}
+          ]) == 1 ->
+            increment
+
+          true ->
+            inc(table, key, scale, increment)
+        end
     end
   end
 

--- a/test/hammer/atomic/clean_test.exs
+++ b/test/hammer/atomic/clean_test.exs
@@ -7,6 +7,14 @@ defmodule Hammer.Atomic.CleanTest do
     use Hammer, backend: :atomic
   end
 
+  defmodule RateAtomicLimitFixWindowPerKey do
+    use Hammer, backend: :atomic, algorithm: :fix_window_per_key
+  end
+
+  defmodule RateAtomicBeforeCleanFixWindowPerKey do
+    use Hammer, backend: :atomic, algorithm: :fix_window_per_key
+  end
+
   defmodule RateAtomicLimitLeakyBucket do
     use Hammer, backend: :atomic, algorithm: :leaky_bucket
   end
@@ -53,6 +61,23 @@ defmodule Hammer.Atomic.CleanTest do
     # Wait for cleanup to occur by polling the table
     eventually(fn ->
       :ets.tab2list(RateAtomicLimit) == []
+    end)
+  end
+
+  test "cleaning works for fix_window_per_key" do
+    start_supervised!({RateAtomicLimitFixWindowPerKey, clean_period: 50, key_older_than: 10})
+
+    key = "key"
+    scale = 100
+    count = 10
+
+    assert {:allow, 1} = RateAtomicLimitFixWindowPerKey.hit(key, scale, count)
+
+    assert [_] = :ets.tab2list(RateAtomicLimitFixWindowPerKey)
+
+    # Wait for cleanup to occur by polling the table
+    eventually(fn ->
+      :ets.tab2list(RateAtomicLimitFixWindowPerKey) == []
     end)
   end
 
@@ -110,6 +135,29 @@ defmodule Hammer.Atomic.CleanTest do
 
       eventually(fn ->
         :ets.tab2list(RateAtomicBeforeClean) == []
+      end)
+    end
+
+    test "receives correct algorithm atom and entries for fix_window_per_key" do
+      test_pid = self()
+
+      callback = fn algorithm, entries ->
+        send(test_pid, {:before_clean, algorithm, entries})
+      end
+
+      start_supervised!(
+        {RateAtomicBeforeCleanFixWindowPerKey,
+         clean_period: 50, key_older_than: 10, before_clean: callback}
+      )
+
+      assert {:allow, 1} = RateAtomicBeforeCleanFixWindowPerKey.hit("user_1", 100, 10)
+
+      assert_receive {:before_clean, :fix_window_per_key, entries}, 5000
+      assert [%{key: "user_1", value: 1, expired_at: expired_at}] = entries
+      assert is_integer(expired_at)
+
+      eventually(fn ->
+        :ets.tab2list(RateAtomicBeforeCleanFixWindowPerKey) == []
       end)
     end
 

--- a/test/hammer/atomic/fix_window_per_key_test.exs
+++ b/test/hammer/atomic/fix_window_per_key_test.exs
@@ -1,0 +1,241 @@
+defmodule Hammer.Atomic.FixWindowPerKeyTest do
+  use ExUnit.Case, async: true
+
+  alias Hammer.Atomic.FixWindowPerKey
+
+  setup do
+    table = :ets.new(:hammer_atomic_fix_window_per_key_test, FixWindowPerKey.ets_opts())
+    {:ok, table: table}
+  end
+
+  describe "hit" do
+    test "returns {:allow, 1} tuple on first access", %{table: table} do
+      key = "key"
+      scale = :timer.seconds(10)
+      limit = 10
+
+      assert {:allow, 1} = FixWindowPerKey.hit(table, key, scale, limit, 1)
+    end
+
+    test "returns incrementing counts on in-limit checks", %{table: table} do
+      key = "key"
+      scale = :timer.minutes(10)
+      limit = 10
+
+      assert {:allow, 1} = FixWindowPerKey.hit(table, key, scale, limit, 1)
+      assert {:allow, 2} = FixWindowPerKey.hit(table, key, scale, limit, 1)
+      assert {:allow, 3} = FixWindowPerKey.hit(table, key, scale, limit, 1)
+      assert {:allow, 4} = FixWindowPerKey.hit(table, key, scale, limit, 1)
+    end
+
+    test "returns expected tuples on mix of in-limit and out-of-limit checks", %{table: table} do
+      key = "key"
+      scale = :timer.minutes(10)
+      limit = 2
+
+      assert {:allow, 1} = FixWindowPerKey.hit(table, key, scale, limit, 1)
+      assert {:allow, 2} = FixWindowPerKey.hit(table, key, scale, limit, 1)
+      assert {:deny, _retry_after} = FixWindowPerKey.hit(table, key, scale, limit, 1)
+      assert {:deny, _retry_after} = FixWindowPerKey.hit(table, key, scale, limit, 1)
+    end
+
+    test "returns expected tuples after waiting for the next window", %{table: table} do
+      key = "key"
+      scale = 100
+      limit = 2
+
+      assert {:allow, 1} = FixWindowPerKey.hit(table, key, scale, limit, 1)
+      assert {:allow, 2} = FixWindowPerKey.hit(table, key, scale, limit, 1)
+      assert {:deny, retry_after} = FixWindowPerKey.hit(table, key, scale, limit, 1)
+
+      :timer.sleep(retry_after + 5)
+
+      assert {:allow, 1} = FixWindowPerKey.hit(table, key, scale, limit, 1)
+      assert {:allow, 2} = FixWindowPerKey.hit(table, key, scale, limit, 1)
+      assert {:deny, _retry_after} = FixWindowPerKey.hit(table, key, scale, limit, 1)
+    end
+
+    test "with custom increment", %{table: table} do
+      key = "cost-key"
+      scale = :timer.seconds(1)
+      limit = 10
+
+      assert {:allow, 4} = FixWindowPerKey.hit(table, key, scale, limit, 4)
+      assert {:allow, 9} = FixWindowPerKey.hit(table, key, scale, limit, 5)
+      assert {:deny, _retry_after} = FixWindowPerKey.hit(table, key, scale, limit, 3)
+    end
+
+    test "mixing default and custom increment", %{table: table} do
+      key = "cost-key"
+      scale = :timer.seconds(1)
+      limit = 10
+
+      assert {:allow, 3} = FixWindowPerKey.hit(table, key, scale, limit, 3)
+      assert {:allow, 4} = FixWindowPerKey.hit(table, key, scale, limit, 1)
+      assert {:allow, 5} = FixWindowPerKey.hit(table, key, scale, limit, 1)
+      assert {:allow, 9} = FixWindowPerKey.hit(table, key, scale, limit, 4)
+      assert {:allow, 10} = FixWindowPerKey.hit(table, key, scale, limit, 1)
+      assert {:deny, _retry_after} = FixWindowPerKey.hit(table, key, scale, limit, 2)
+    end
+
+    test "race condition", %{table: table} do
+      key = "key"
+      scale = :timer.seconds(10)
+      limit = 10
+
+      task1 =
+        Task.async(fn ->
+          for _ <- 1..2 do
+            FixWindowPerKey.hit(table, key, scale, limit, 1)
+          end
+        end)
+
+      task2 =
+        Task.async(fn ->
+          for _ <- 1..2 do
+            FixWindowPerKey.hit(table, key, scale, limit, 1)
+          end
+        end)
+
+      Task.await(task1, 5000)
+      Task.await(task2, 5000)
+
+      assert FixWindowPerKey.get(table, key, scale) == 4
+    end
+  end
+
+  describe "per-key window anchoring" do
+    test "different keys have independent windows anchored to their first hit", %{table: table} do
+      scale = :timer.seconds(10)
+      limit = 10
+
+      assert {:allow, 1} = FixWindowPerKey.hit(table, "a", scale, limit, 1)
+      :timer.sleep(50)
+      assert {:allow, 1} = FixWindowPerKey.hit(table, "b", scale, limit, 1)
+
+      expires_a = FixWindowPerKey.expires_at(table, "a", scale)
+      expires_b = FixWindowPerKey.expires_at(table, "b", scale)
+
+      assert expires_b - expires_a >= 40
+      assert expires_b - expires_a <= 200
+    end
+
+    test "subsequent hits in active window do not extend the window", %{table: table} do
+      scale = :timer.seconds(10)
+      limit = 10
+
+      assert {:allow, 1} = FixWindowPerKey.hit(table, "key", scale, limit, 1)
+      first_expires_at = FixWindowPerKey.expires_at(table, "key", scale)
+
+      :timer.sleep(20)
+      assert {:allow, 2} = FixWindowPerKey.hit(table, "key", scale, limit, 1)
+      second_expires_at = FixWindowPerKey.expires_at(table, "key", scale)
+
+      assert second_expires_at == first_expires_at
+    end
+
+    test "next hit after expiry opens a new window anchored to that hit", %{table: table} do
+      scale = 100
+      limit = 5
+
+      assert {:allow, 1} = FixWindowPerKey.hit(table, "key", scale, limit, 1)
+      first_expires_at = FixWindowPerKey.expires_at(table, "key", scale)
+
+      :timer.sleep(scale + 20)
+
+      assert {:allow, 1} = FixWindowPerKey.hit(table, "key", scale, limit, 1)
+      new_expires_at = FixWindowPerKey.expires_at(table, "key", scale)
+
+      assert new_expires_at > first_expires_at
+      assert new_expires_at - first_expires_at >= scale
+    end
+  end
+
+  describe "inc" do
+    test "increments the count for the given key and scale", %{table: table} do
+      key = "key"
+      scale = :timer.seconds(10)
+
+      assert FixWindowPerKey.get(table, key, scale) == 0
+
+      assert FixWindowPerKey.inc(table, key, scale, 1) == 1
+      assert FixWindowPerKey.get(table, key, scale) == 1
+
+      assert FixWindowPerKey.inc(table, key, scale, 1) == 2
+      assert FixWindowPerKey.get(table, key, scale) == 2
+
+      assert FixWindowPerKey.inc(table, key, scale, 1) == 3
+      assert FixWindowPerKey.get(table, key, scale) == 3
+
+      assert FixWindowPerKey.inc(table, key, scale, 1) == 4
+      assert FixWindowPerKey.get(table, key, scale) == 4
+    end
+
+    test "resets the counter after expiry", %{table: table} do
+      key = "key"
+      scale = 100
+
+      assert FixWindowPerKey.inc(table, key, scale, 1) == 1
+      assert FixWindowPerKey.inc(table, key, scale, 1) == 2
+
+      :timer.sleep(scale + 20)
+
+      assert FixWindowPerKey.inc(table, key, scale, 1) == 1
+    end
+  end
+
+  describe "expires_at" do
+    test "returns 0 for unknown key", %{table: table} do
+      assert FixWindowPerKey.expires_at(table, "unknown", :timer.seconds(10)) == 0
+    end
+
+    test "returns the expiration timestamp after a hit", %{table: table} do
+      key = "key"
+      scale = :timer.seconds(10)
+
+      assert {:allow, 1} = FixWindowPerKey.hit(table, key, scale, 10, 1)
+
+      expires_at = FixWindowPerKey.expires_at(table, key, scale)
+      now = System.system_time(:millisecond)
+
+      assert expires_at > now
+      assert expires_at <= now + scale
+    end
+
+    test "returns 0 after window expires", %{table: table} do
+      key = "key"
+      scale = 100
+
+      assert {:allow, 1} = FixWindowPerKey.hit(table, key, scale, 10, 1)
+      assert FixWindowPerKey.expires_at(table, key, scale) > 0
+
+      :timer.sleep(scale + 20)
+
+      assert FixWindowPerKey.expires_at(table, key, scale) == 0
+    end
+  end
+
+  describe "get/set" do
+    test "get returns the count set for the given key and scale", %{table: table} do
+      key = "key"
+      scale = :timer.seconds(10)
+      count = 10
+
+      assert FixWindowPerKey.get(table, key, scale) == 0
+      assert FixWindowPerKey.set(table, key, scale, count) == count
+      assert FixWindowPerKey.get(table, key, scale) == count
+    end
+
+    test "get returns 0 after the window expires", %{table: table} do
+      key = "key"
+      scale = 100
+
+      assert {:allow, 1} = FixWindowPerKey.hit(table, key, scale, 10, 1)
+      assert FixWindowPerKey.get(table, key, scale) == 1
+
+      :timer.sleep(scale + 20)
+
+      assert FixWindowPerKey.get(table, key, scale) == 0
+    end
+  end
+end

--- a/test/hammer/atomic/fix_window_per_key_test.exs
+++ b/test/hammer/atomic/fix_window_per_key_test.exs
@@ -151,6 +151,35 @@ defmodule Hammer.Atomic.FixWindowPerKeyTest do
     end
   end
 
+  describe "concurrent expiry reset" do
+    test "every concurrent hit on an expired key is counted", %{table: table} do
+      key = "race"
+      scale = :timer.seconds(5)
+      limit = 100_000
+
+      atomic = :atomics.new(2, signed: false)
+      :ets.insert(table, {key, atomic})
+
+      n = 200
+
+      tasks =
+        Enum.map(1..n, fn _ ->
+          Task.async(fn ->
+            receive do
+              :go -> FixWindowPerKey.hit(table, key, scale, limit, 1)
+            end
+          end)
+        end)
+
+      Enum.each(tasks, &send(&1.pid, :go))
+      results = Task.await_many(tasks, 5_000)
+
+      allows = Enum.count(results, &match?({:allow, _}, &1))
+      assert allows == n
+      assert FixWindowPerKey.get(table, key, scale) == allows
+    end
+  end
+
   describe "inc" do
     test "increments the count for the given key and scale", %{table: table} do
       key = "key"

--- a/test/hammer/ets/clean_test.exs
+++ b/test/hammer/ets/clean_test.exs
@@ -7,6 +7,14 @@ defmodule Hammer.ETS.CleanTest do
     use Hammer, backend: :ets
   end
 
+  defmodule RateLimitFixWindowPerKey do
+    use Hammer, backend: :ets, algorithm: :fix_window_per_key
+  end
+
+  defmodule RateLimitBeforeCleanFixWindowPerKey do
+    use Hammer, backend: :ets, algorithm: :fix_window_per_key
+  end
+
   defmodule RateLimitSlidingWindow do
     use Hammer, backend: :ets, algorithm: :sliding_window
   end
@@ -61,6 +69,23 @@ defmodule Hammer.ETS.CleanTest do
     # Wait for cleanup to occur by polling the table
     eventually(fn ->
       :ets.tab2list(RateLimit) == []
+    end)
+  end
+
+  test "cleaning works for fix_window_per_key" do
+    start_supervised!({RateLimitFixWindowPerKey, clean_period: 100})
+
+    key = "key"
+    scale = 100
+    count = 10
+
+    assert {:allow, 1} = RateLimitFixWindowPerKey.hit(key, scale, count)
+
+    assert [_] = :ets.tab2list(RateLimitFixWindowPerKey)
+
+    # Wait for cleanup to occur by polling the table
+    eventually(fn ->
+      :ets.tab2list(RateLimitFixWindowPerKey) == []
     end)
   end
 
@@ -133,6 +158,28 @@ defmodule Hammer.ETS.CleanTest do
 
       eventually(fn ->
         :ets.tab2list(RateLimitBeforeClean) == []
+      end)
+    end
+
+    test "receives correct algorithm atom and entries for fix_window_per_key" do
+      test_pid = self()
+
+      callback = fn algorithm, entries ->
+        send(test_pid, {:before_clean, algorithm, entries})
+      end
+
+      start_supervised!(
+        {RateLimitBeforeCleanFixWindowPerKey, clean_period: 100, before_clean: callback}
+      )
+
+      assert {:allow, 1} = RateLimitBeforeCleanFixWindowPerKey.hit("user_1", 100, 10)
+
+      assert_receive {:before_clean, :fix_window_per_key, entries}, 5000
+      assert [%{key: "user_1", value: 1, expired_at: expired_at}] = entries
+      assert is_integer(expired_at)
+
+      eventually(fn ->
+        :ets.tab2list(RateLimitBeforeCleanFixWindowPerKey) == []
       end)
     end
 

--- a/test/hammer/ets/fix_window_per_key_test.exs
+++ b/test/hammer/ets/fix_window_per_key_test.exs
@@ -190,6 +190,34 @@ defmodule Hammer.ETS.FixWindowPerKeyTest do
     end
   end
 
+  describe "concurrent expiry reset" do
+    test "every concurrent hit on an expired key is counted", %{table: table} do
+      key = "race"
+      scale = :timer.seconds(5)
+      limit = 100_000
+
+      :ets.insert(table, {key, 0, System.system_time(:millisecond) - 1})
+
+      n = 200
+
+      tasks =
+        Enum.map(1..n, fn _ ->
+          Task.async(fn ->
+            receive do
+              :go -> FixWindowPerKey.hit(table, key, scale, limit, 1)
+            end
+          end)
+        end)
+
+      Enum.each(tasks, &send(&1.pid, :go))
+      results = Task.await_many(tasks, 5_000)
+
+      allows = Enum.count(results, &match?({:allow, _}, &1))
+      assert allows == n
+      assert FixWindowPerKey.get(table, key, scale) == allows
+    end
+  end
+
   describe "get/set" do
     test "get returns the count set for the given key and scale", %{table: table} do
       key = "key"

--- a/test/hammer/ets/fix_window_per_key_test.exs
+++ b/test/hammer/ets/fix_window_per_key_test.exs
@@ -1,0 +1,216 @@
+defmodule Hammer.ETS.FixWindowPerKeyTest do
+  use ExUnit.Case, async: true
+
+  alias Hammer.ETS.FixWindowPerKey
+
+  setup do
+    table = :ets.new(:hammer_fix_window_per_key_test, FixWindowPerKey.ets_opts())
+    {:ok, table: table}
+  end
+
+  describe "hit" do
+    test "returns {:allow, 1} tuple on first access", %{table: table} do
+      key = "key"
+      scale = :timer.seconds(10)
+      limit = 10
+
+      assert {:allow, 1} = FixWindowPerKey.hit(table, key, scale, limit, 1)
+    end
+
+    test "returns incrementing counts on in-limit checks", %{table: table} do
+      key = "key"
+      scale = :timer.minutes(10)
+      limit = 10
+
+      assert {:allow, 1} = FixWindowPerKey.hit(table, key, scale, limit, 1)
+      assert {:allow, 2} = FixWindowPerKey.hit(table, key, scale, limit, 1)
+      assert {:allow, 3} = FixWindowPerKey.hit(table, key, scale, limit, 1)
+      assert {:allow, 4} = FixWindowPerKey.hit(table, key, scale, limit, 1)
+    end
+
+    test "returns expected tuples on mix of in-limit and out-of-limit checks", %{table: table} do
+      key = "key"
+      scale = :timer.minutes(10)
+      limit = 2
+
+      assert {:allow, 1} = FixWindowPerKey.hit(table, key, scale, limit, 1)
+      assert {:allow, 2} = FixWindowPerKey.hit(table, key, scale, limit, 1)
+      assert {:deny, _retry_after} = FixWindowPerKey.hit(table, key, scale, limit, 1)
+      assert {:deny, _retry_after} = FixWindowPerKey.hit(table, key, scale, limit, 1)
+    end
+
+    test "returns expected tuples after waiting for the next window", %{table: table} do
+      key = "key"
+      scale = 100
+      limit = 2
+
+      assert {:allow, 1} = FixWindowPerKey.hit(table, key, scale, limit, 1)
+      assert {:allow, 2} = FixWindowPerKey.hit(table, key, scale, limit, 1)
+      assert {:deny, retry_after} = FixWindowPerKey.hit(table, key, scale, limit, 1)
+
+      :timer.sleep(retry_after + 5)
+
+      assert {:allow, 1} = FixWindowPerKey.hit(table, key, scale, limit, 1)
+      assert {:allow, 2} = FixWindowPerKey.hit(table, key, scale, limit, 1)
+      assert {:deny, _retry_after} = FixWindowPerKey.hit(table, key, scale, limit, 1)
+    end
+
+    test "with custom increment", %{table: table} do
+      key = "cost-key"
+      scale = :timer.seconds(1)
+      limit = 10
+
+      assert {:allow, 4} = FixWindowPerKey.hit(table, key, scale, limit, 4)
+      assert {:allow, 9} = FixWindowPerKey.hit(table, key, scale, limit, 5)
+      assert {:deny, _retry_after} = FixWindowPerKey.hit(table, key, scale, limit, 3)
+    end
+
+    test "mixing default and custom increment", %{table: table} do
+      key = "cost-key"
+      scale = :timer.seconds(1)
+      limit = 10
+
+      assert {:allow, 3} = FixWindowPerKey.hit(table, key, scale, limit, 3)
+      assert {:allow, 4} = FixWindowPerKey.hit(table, key, scale, limit, 1)
+      assert {:allow, 5} = FixWindowPerKey.hit(table, key, scale, limit, 1)
+      assert {:allow, 9} = FixWindowPerKey.hit(table, key, scale, limit, 4)
+      assert {:allow, 10} = FixWindowPerKey.hit(table, key, scale, limit, 1)
+      assert {:deny, _retry_after} = FixWindowPerKey.hit(table, key, scale, limit, 2)
+    end
+  end
+
+  describe "per-key window anchoring" do
+    test "different keys have independent windows anchored to their first hit", %{table: table} do
+      scale = :timer.seconds(10)
+      limit = 10
+
+      assert {:allow, 1} = FixWindowPerKey.hit(table, "a", scale, limit, 1)
+      :timer.sleep(50)
+      assert {:allow, 1} = FixWindowPerKey.hit(table, "b", scale, limit, 1)
+
+      expires_a = FixWindowPerKey.expires_at(table, "a", scale)
+      expires_b = FixWindowPerKey.expires_at(table, "b", scale)
+
+      assert expires_b - expires_a >= 40
+      assert expires_b - expires_a <= 200
+    end
+
+    test "subsequent hits in active window do not extend the window", %{table: table} do
+      scale = :timer.seconds(10)
+      limit = 10
+
+      assert {:allow, 1} = FixWindowPerKey.hit(table, "key", scale, limit, 1)
+      first_expires_at = FixWindowPerKey.expires_at(table, "key", scale)
+
+      :timer.sleep(20)
+      assert {:allow, 2} = FixWindowPerKey.hit(table, "key", scale, limit, 1)
+      second_expires_at = FixWindowPerKey.expires_at(table, "key", scale)
+
+      assert second_expires_at == first_expires_at
+    end
+
+    test "next hit after expiry opens a new window anchored to that hit", %{table: table} do
+      scale = 100
+      limit = 5
+
+      assert {:allow, 1} = FixWindowPerKey.hit(table, "key", scale, limit, 1)
+      first_expires_at = FixWindowPerKey.expires_at(table, "key", scale)
+
+      :timer.sleep(scale + 20)
+
+      assert {:allow, 1} = FixWindowPerKey.hit(table, "key", scale, limit, 1)
+      new_expires_at = FixWindowPerKey.expires_at(table, "key", scale)
+
+      assert new_expires_at > first_expires_at
+      assert new_expires_at - first_expires_at >= scale
+    end
+  end
+
+  describe "inc" do
+    test "increments the count for the given key and scale", %{table: table} do
+      key = "key"
+      scale = :timer.seconds(10)
+
+      assert FixWindowPerKey.get(table, key, scale) == 0
+
+      assert FixWindowPerKey.inc(table, key, scale, 1) == 1
+      assert FixWindowPerKey.get(table, key, scale) == 1
+
+      assert FixWindowPerKey.inc(table, key, scale, 1) == 2
+      assert FixWindowPerKey.get(table, key, scale) == 2
+
+      assert FixWindowPerKey.inc(table, key, scale, 1) == 3
+      assert FixWindowPerKey.get(table, key, scale) == 3
+
+      assert FixWindowPerKey.inc(table, key, scale, 1) == 4
+      assert FixWindowPerKey.get(table, key, scale) == 4
+    end
+
+    test "resets the counter after expiry", %{table: table} do
+      key = "key"
+      scale = 100
+
+      assert FixWindowPerKey.inc(table, key, scale, 1) == 1
+      assert FixWindowPerKey.inc(table, key, scale, 1) == 2
+
+      :timer.sleep(scale + 20)
+
+      assert FixWindowPerKey.inc(table, key, scale, 1) == 1
+    end
+  end
+
+  describe "expires_at" do
+    test "returns 0 for unknown key", %{table: table} do
+      assert FixWindowPerKey.expires_at(table, "unknown", :timer.seconds(10)) == 0
+    end
+
+    test "returns the expiration timestamp after a hit", %{table: table} do
+      key = "key"
+      scale = :timer.seconds(10)
+
+      assert {:allow, 1} = FixWindowPerKey.hit(table, key, scale, 10, 1)
+
+      expires_at = FixWindowPerKey.expires_at(table, key, scale)
+      now = System.system_time(:millisecond)
+
+      assert expires_at > now
+      assert expires_at <= now + scale
+    end
+
+    test "returns 0 after window expires", %{table: table} do
+      key = "key"
+      scale = 100
+
+      assert {:allow, 1} = FixWindowPerKey.hit(table, key, scale, 10, 1)
+      assert FixWindowPerKey.expires_at(table, key, scale) > 0
+
+      :timer.sleep(scale + 20)
+
+      assert FixWindowPerKey.expires_at(table, key, scale) == 0
+    end
+  end
+
+  describe "get/set" do
+    test "get returns the count set for the given key and scale", %{table: table} do
+      key = "key"
+      scale = :timer.seconds(10)
+      count = 10
+
+      assert FixWindowPerKey.get(table, key, scale) == 0
+      assert FixWindowPerKey.set(table, key, scale, count) == count
+      assert FixWindowPerKey.get(table, key, scale) == count
+    end
+
+    test "get returns 0 after the window expires", %{table: table} do
+      key = "key"
+      scale = 100
+
+      assert {:allow, 1} = FixWindowPerKey.hit(table, key, scale, 10, 1)
+      assert FixWindowPerKey.get(table, key, scale) == 1
+
+      :timer.sleep(scale + 20)
+
+      assert FixWindowPerKey.get(table, key, scale) == 0
+    end
+  end
+end


### PR DESCRIPTION
 Closes #181.

  ## Summary

  Adds `:fix_window_per_key` to both the ETS and Atomic backends. It's a fixed-window variant whose window is anchored
   to each key's **first hit** instead of a globally-aligned wall-clock epoch (multiples of `scale` since Unix epoch,
  like `:fix_window` uses today).

  Same one-entry-per-key memory profile as `:fix_window`. The 2× boundary burst is still theoretically possible per
  key, but boundaries are no longer globally synchronized — they can't be timed deterministically by an attacker, and
  a key has to wait a full `scale` between burst opportunities. Same semantics as the common Redis `INCR + EXPIRE NX`
  pattern.

  Naming chosen deliberately over `:rolling_window` — the algorithm is mechanically a fixed window, just with a
  per-key epoch. The docstring is explicit that the 2× burst is still possible, so users reaching for this won't
  expect `:sliding_window`-level precision.

  ## What's included

  - `Hammer.ETS.FixWindowPerKey` and `Hammer.Atomic.FixWindowPerKey`
  - Dispatch wiring in `Hammer.ETS` and `Hammer.Atomic` (incl. `before_clean` algorithm name)
  - Atomic backend reuses the existing `clean_fix_window` path (identical row layout)
  - Test files mirroring the existing `fix_window` tests, plus distinguishing tests for per-key window anchoring,
  expiry behavior, and the atomic race condition
  - `before_clean` callback tests in both `clean_test.exs` files
  - README algorithm table, comparison section, and selection guide updated
  - CHANGELOG `## Unreleased` entry

  ## Test plan

  - [x] `mix test` — 129/129 passing
  - [x] `mix credo --strict` — clean
  - [x] `mix format --check-formatted` — clean