### PR TITLE
fix: guard reset path against concurrent overwrites in ETS and Atomic backends

### DIFF
--- a/lib/hammer/atomic/fix_window_per_key.ex
+++ b/lib/hammer/atomic/fix_window_per_key.ex
@@ -102,16 +102,32 @@ defmodule Hammer.Atomic.FixWindowPerKey do
     end
   end
 
+  # Sentinel written to expires_at slot while a reset is in progress.
+  # All other processes that see this value spin-retry until the winner
+  # has written both the new counter and the real expires_at.
+  @reset_lock 0xFFFFFFFFFFFFFFFF
+
   defp do_hit(atomic, now, scale, limit, increment) do
     expires_at = :atomics.get(atomic, 2)
 
-    if expires_at > now do
-      count = :atomics.add_get(atomic, 1, increment)
-      if count <= limit, do: {:allow, count}, else: {:deny, expires_at - now}
-    else
-      :atomics.put(atomic, 1, increment)
-      :atomics.exchange(atomic, 2, now + scale)
-      if increment <= limit, do: {:allow, increment}, else: {:deny, scale}
+    cond do
+      expires_at == @reset_lock ->
+        do_hit(atomic, now, scale, limit, increment)
+
+      expires_at > now ->
+        count = :atomics.add_get(atomic, 1, increment)
+        if count <= limit, do: {:allow, count}, else: {:deny, expires_at - now}
+
+      true ->
+        case :atomics.compare_exchange(atomic, 2, expires_at, @reset_lock) do
+          :ok ->
+            :atomics.put(atomic, 1, increment)
+            :atomics.put(atomic, 2, now + scale)
+            if increment <= limit, do: {:allow, increment}, else: {:deny, scale}
+
+          _ ->
+            do_hit(atomic, now, scale, limit, increment)
+        end
     end
   end
 
@@ -131,17 +147,29 @@ defmodule Hammer.Atomic.FixWindowPerKey do
       [{_, atomic}] ->
         expires_at = :atomics.get(atomic, 2)
 
-        if expires_at > now do
-          :atomics.add_get(atomic, 1, increment)
-        else
-          new_expires_at = now + scale
-          :atomics.put(atomic, 1, increment)
-          :atomics.exchange(atomic, 2, new_expires_at)
-          increment
+        cond do
+          expires_at == @reset_lock ->
+            inc(table, key, scale, increment)
+
+          expires_at > now ->
+            :atomics.add_get(atomic, 1, increment)
+
+          true ->
+            new_expires_at = now + scale
+
+            case :atomics.compare_exchange(atomic, 2, expires_at, @reset_lock) do
+              :ok ->
+                :atomics.put(atomic, 1, increment)
+                :atomics.put(atomic, 2, new_expires_at)
+                increment
+
+              _ ->
+                inc(table, key, scale, increment)
+            end
         end
 
       [] ->
-        :ets.insert(table, {key, :atomics.new(2, signed: false)})
+        :ets.insert_new(table, {key, :atomics.new(2, signed: false)})
         inc(table, key, scale, increment)
     end
   end

--- a/lib/hammer/ets/fix_window_per_key.ex
+++ b/lib/hammer/ets/fix_window_per_key.ex
@@ -120,12 +120,19 @@ defmodule Hammer.ETS.FixWindowPerKey do
 
       _ ->
         new_expires_at = now + scale
-        :ets.insert(table, {key, increment, new_expires_at})
 
-        if increment <= limit do
-          {:allow, increment}
-        else
-          {:deny, scale}
+        cond do
+          :ets.insert_new(table, {key, increment, new_expires_at}) ->
+            if increment <= limit, do: {:allow, increment}, else: {:deny, scale}
+
+          :ets.select_replace(table, [
+            {{key, :_, :"$1"}, [{:<, :"$1", {:const, now}}],
+             [{:const, {key, increment, new_expires_at}}]}
+          ]) == 1 ->
+            if increment <= limit, do: {:allow, increment}, else: {:deny, scale}
+
+          true ->
+            hit(table, key, scale, limit, increment)
         end
     end
   end
@@ -148,8 +155,20 @@ defmodule Hammer.ETS.FixWindowPerKey do
 
       _ ->
         new_expires_at = now + scale
-        :ets.insert(table, {key, increment, new_expires_at})
-        increment
+
+        cond do
+          :ets.insert_new(table, {key, increment, new_expires_at}) ->
+            increment
+
+          :ets.select_replace(table, [
+            {{key, :_, :"$1"}, [{:<, :"$1", {:const, now}}],
+             [{:const, {key, increment, new_expires_at}}]}
+          ]) == 1 ->
+            increment
+
+          true ->
+            inc(table, key, scale, increment)
+        end
     end
   end
 

--- a/test/hammer/atomic/fix_window_per_key_test.exs
+++ b/test/hammer/atomic/fix_window_per_key_test.exs
@@ -151,6 +151,35 @@ defmodule Hammer.Atomic.FixWindowPerKeyTest do
     end
   end
 
+  describe "concurrent expiry reset" do
+    test "every concurrent hit on an expired key is counted", %{table: table} do
+      key = "race"
+      scale = :timer.seconds(5)
+      limit = 100_000
+
+      atomic = :atomics.new(2, signed: false)
+      :ets.insert(table, {key, atomic})
+
+      n = 200
+
+      tasks =
+        Enum.map(1..n, fn _ ->
+          Task.async(fn ->
+            receive do
+              :go -> FixWindowPerKey.hit(table, key, scale, limit, 1)
+            end
+          end)
+        end)
+
+      Enum.each(tasks, &send(&1.pid, :go))
+      results = Task.await_many(tasks, 5_000)
+
+      allows = Enum.count(results, &match?({:allow, _}, &1))
+      assert allows == n
+      assert FixWindowPerKey.get(table, key, scale) == allows
+    end
+  end
+
   describe "inc" do
     test "increments the count for the given key and scale", %{table: table} do
       key = "key"

--- a/test/hammer/ets/fix_window_per_key_test.exs
+++ b/test/hammer/ets/fix_window_per_key_test.exs
@@ -190,6 +190,34 @@ defmodule Hammer.ETS.FixWindowPerKeyTest do
     end
   end
 
+  describe "concurrent expiry reset" do
+    test "every concurrent hit on an expired key is counted", %{table: table} do
+      key = "race"
+      scale = :timer.seconds(5)
+      limit = 100_000
+
+      :ets.insert(table, {key, 0, System.system_time(:millisecond) - 1})
+
+      n = 200
+
+      tasks =
+        Enum.map(1..n, fn _ ->
+          Task.async(fn ->
+            receive do
+              :go -> FixWindowPerKey.hit(table, key, scale, limit, 1)
+            end
+          end)
+        end)
+
+      Enum.each(tasks, &send(&1.pid, :go))
+      results = Task.await_many(tasks, 5_000)
+
+      allows = Enum.count(results, &match?({:allow, _}, &1))
+      assert allows == n
+      assert FixWindowPerKey.get(table, key, scale) == allows
+    end
+  end
+
   describe "get/set" do
     test "get returns the count set for the given key and scale", %{table: table} do
       key = "key"


### PR DESCRIPTION
# Fix concurrent window-reset race in `fix_window_per_key` (ETS and Atomic)

## Background

PR #183 introduced `:fix_window_per_key`, a per-key fixed-window algorithm that anchors each key's window to its **first hit** rather than a shared wall-clock epoch. The feature itself is sound; this PR addresses a correctness bug in the reset path that appears when multiple processes hit the same key at the moment its window expires.

---

## The race condition

### ETS backend — `hit/5` and `inc/4`

When a key's window has expired (or the key is absent), `hit/5` falls through to:

```elixir
_ ->
  new_expires_at = now + scale
  :ets.insert(table, {key, increment, new_expires_at})   # ← not conditional
  {:allow, increment}
```

`:ets.insert/2` is an unconditional overwrite. If N processes all call `:ets.lookup` and observe `expires_at ≤ now` before any of them completes the insert, each one will write `{key, 1, new_expires_at}` and the last write wins. All N callers receive `{:allow, 1}`, but the stored counter is `1` — N−1 hits are silently dropped.

The same pattern exists in `inc/4`.

### Atomic backend — `do_hit/5` and `inc/4`

The reset path in `do_hit` uses two separate atomic operations:

```elixir
:atomics.put(atomic, 1, increment)        # reset counter  ← not conditional
:atomics.exchange(atomic, 2, now + scale) # publish window
```

These are not atomic *together*. N processes that all read `expires_at ≤ now` before any `exchange` completes will each call `put(1, increment)`, overwriting one another. The last `put` wins and the counter is `increment` while N `{:allow, increment}` responses have already been returned.

Additionally, `inc/4` in the Atomic backend used `:ets.insert` (unconditional) instead of `:ets.insert_new` for the initial atomics-ref creation, matching a separate but related race already correctly avoided in `hit/5`.

### Why `:fix_window` does not have this problem

`Hammer.ETS.FixWindow` and `Hammer.Atomic.FixWindow` use `{key, window_number}` as the ETS key. A new window is a genuinely new key; the active-window `update_counter` / `add_get` path is reached on the very first hit. There is no "reset in place" of an existing key — the problem is specific to `:fix_window_per_key`.

---

## Fix

### ETS — `insert_new` + `select_replace` + retry

Replace the bare `:ets.insert` with a three-step CAS-style sequence:

```
1. :ets.insert_new   → wins if the key does not exist yet (atomic)
2. :ets.select_replace with guard expires_at < now
                     → wins if the key exists but is expired (atomic)
3. recurse           → someone else claimed the window; next call lands in
                       the active-window update_counter path
```

Both `:ets.insert_new` and `:ets.select_replace` are ETS operations that guarantee at most one writer succeeds. Exactly one process resets the counter; all others fall back to the `update_counter` path once the window is live.

### Atomic — `compare_exchange` + reset-lock sentinel

Replace the non-atomic `put + exchange` pair with a CAS on the `expires_at` slot using a sentinel value (`@reset_lock = 0xFFFFFFFFFFFFFFFF`, the unsigned 64-bit max — unreachable by any real timestamp):

```
1. compare_exchange(expires_at, old_val, @reset_lock)
   → exactly one process wins ownership of the reset
2. Winner: put(counter, increment), put(expires_at, now + scale)
3. Losers that read @reset_lock: spin-retry until step 2 completes,
   then use add_get on the now-active window
4. Losers whose CAS fails for any other reason: recurse immediately
```

While `@reset_lock` is set, no other process can enter the `add_get` path (the `cond` checks `== @reset_lock` before `> now`). This guarantees the winner's `put(counter)` is never overwritten by a stale peer's `put` before the real `expires_at` is published.

---

## Files changed

| File | Change |
|------|--------|
| `lib/hammer/ets/fix_window_per_key.ex` | `hit/5`, `inc/4`: replace `:ets.insert` with `insert_new` + `select_replace` + recurse |
| `lib/hammer/atomic/fix_window_per_key.ex` | `do_hit/5`: CAS with `@reset_lock` sentinel; `inc/4`: same CAS pattern + fix `insert` → `insert_new` for atomics-ref creation |
| `test/hammer/ets/fix_window_per_key_test.exs` | Add `"concurrent expiry reset"` describe: 200-task stress test asserting `get == allows` after a synchronized expiry-boundary hit |
| `test/hammer/atomic/fix_window_per_key_test.exs` | Same stress test for the Atomic backend |

---

## Tests

The new `"concurrent expiry reset"` tests in both files follow the same structure:

1. Pre-plant an expired entry so every task enters the reset path.
2. Spawn 200 tasks, all blocked on a `receive :go` barrier.
3. Release all at once to maximise overlap at the reset boundary.
4. Assert `get(table, key, scale) == total_allows` — any under-count reveals a lost reset.

The stress tests pass consistently with the fix in place. The invariant they protect (`counter == allows`) cannot be satisfied by the unfixed code under concurrent expiry pressure on multi-core schedulers.

All 131 existing tests continue to pass.

---

## Notes for reviewers

- The `@reset_lock` sentinel is safe: `now` is milliseconds since epoch (~1.7 × 10¹²); `now + scale` for any realistic scale never approaches `2⁶⁴ − 1 ≈ 1.8 × 10¹⁹`.
- The retry loops (`do_hit` calling itself, `inc` calling itself) terminate: after the winner publishes `now + scale`, all spinners read a valid `expires_at > now` and proceed via `add_get`. There is no livelock — each reset event has exactly one winner.
- `Hammer.ETS.FixWindow` and `Hammer.Atomic.FixWindow` are not touched; their `{key, window}` keying strategy does not have this class of bug.