### PR TITLE
chore: Release 7.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 7.4.0 - 2026-05-19
 
 - Add `:fix_window_per_key` algorithm for ETS and Atomic backends — a fixed-window variant whose window is anchored to first hit per key instead of a globally-aligned wall-clock epoch. Same one-entry-per-key memory profile as `:fix_window`. The 2x boundary burst is still possible per key, but boundaries are no longer globally synchronized. (#181)
 

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Hammer.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/ExHammer/hammer"
-  @version "7.3.0"
+  @version "7.4.0"
 
   def project do
     [


### PR DESCRIPTION
Cut the 7.4.0 minor release.

  - Bump version `7.3.0` → `7.4.0` in `mix.exs`
  - Promote the `Unreleased` changelog section to `## 7.4.0 - 2026-05-19`

  Minor bump: the release contains a new feature (`:fix_window_per_key`
  algorithm for ETS and Atomic backends, #181) with no breaking changes.